### PR TITLE
[#90579890] foundation names roll back

### DIFF
--- a/app/actors/cms/page/collection.i_collection.go
+++ b/app/actors/cms/page/collection.i_collection.go
@@ -49,7 +49,7 @@ func (it *DefaultCMSPageCollection) List() ([]models.StructListItem, error) {
 // ListAddExtraAttribute allows to obtain additional attributes from  List() function
 func (it *DefaultCMSPageCollection) ListAddExtraAttribute(attribute string) error {
 
-	if utils.IsAmongStr(attribute, "_id", "id", "enabled", "identifier", "title", "pagetitle", "content", "created_at", "updated_at") {
+	if utils.IsAmongStr(attribute, "_id", "id", "enabled", "identifier", "title", "content", "created_at", "updated_at") {
 		if !utils.IsInListStr(attribute, it.listExtraAtributes) {
 			it.listExtraAtributes = append(it.listExtraAtributes, attribute)
 		} else {

--- a/app/actors/cms/page/decl.go
+++ b/app/actors/cms/page/decl.go
@@ -23,7 +23,7 @@ type DefaultCMSPage struct {
 	Enabled    bool
 	Identifier string
 
-	PageTitle   string
+	Title   string
 	Content string
 
 	CreatedAt time.Time

--- a/app/actors/cms/page/page.i_cms_page.go
+++ b/app/actors/cms/page/page.i_cms_page.go
@@ -30,12 +30,12 @@ func (it *DefaultCMSPage) SetIdentifier(newValue string) error {
 
 // GetTitle returns page title
 func (it *DefaultCMSPage) GetTitle() string {
-	return it.PageTitle
+	return it.Title
 }
 
 // SetTitle sets page title value
 func (it *DefaultCMSPage) SetTitle(newValue string) error {
-	it.PageTitle = newValue
+	it.Title = newValue
 	return nil
 }
 
@@ -77,7 +77,7 @@ func (it *DefaultCMSPage) LoadByIdentifier(identifier string) error {
 	it.Identifier = utils.InterfaceToString(record["identifier"])
 	it.Enabled = utils.InterfaceToBool(record["enabled"])
 
-	it.PageTitle = utils.InterfaceToString(record["title"])
+	it.Title = utils.InterfaceToString(record["title"])
 	it.Content = utils.InterfaceToString(record["content"])
 
 	it.CreatedAt = utils.InterfaceToTime(record["created_at"])

--- a/app/actors/cms/page/page.i_object.go
+++ b/app/actors/cms/page/page.i_object.go
@@ -20,7 +20,7 @@ func (it *DefaultCMSPage) Get(attribute string) interface{} {
 		return it.GetEnabled()
 	case "identifier":
 		return it.GetIdentifier()
-	case "pagetitle":
+	case "title":
 		return it.GetTitle()
 	case "content":
 		return it.GetContent()
@@ -44,7 +44,7 @@ func (it *DefaultCMSPage) Set(attribute string, value interface{}) error {
 		return it.SetEnabled(utils.InterfaceToBool(value))
 	case "identifier":
 		return it.SetIdentifier(utils.InterfaceToString(value))
-	case "pagetitle":
+	case "title":
 		return it.SetTitle(utils.InterfaceToString(value))
 	case "content":
 		return it.SetContent(utils.InterfaceToString(value))
@@ -66,9 +66,6 @@ func (it *DefaultCMSPage) FromHashMap(input map[string]interface{}) error {
 		if err := it.Set(attribute, value); err != nil {
 			env.ErrorDispatch(err)
 		}
-		if attribute == "title" {
-			it.Set("pagetitle", value)
-		}
 	}
 
 	return nil
@@ -82,7 +79,7 @@ func (it *DefaultCMSPage) ToHashMap() map[string]interface{} {
 	result["_id"] = it.GetID()
 	result["enabled"] = it.Get("enabled")
 	result["identifier"] = it.Get("identifier")
-	result["pagetitle"] = it.Get("pagetitle")
+	result["title"] = it.Get("title")
 	result["content"] = it.Get("content")
 	result["created_at"] = it.Get("created_at")
 	result["updated_at"] = it.Get("updated_at")
@@ -137,7 +134,7 @@ func (it *DefaultCMSPage) GetAttributesInfo() []models.StructAttributeInfo {
 		models.StructAttributeInfo{
 			Model:      cms.ConstModelNameCMSPage,
 			Collection: ConstCmsPageCollectionName,
-			Attribute:  "pagetitle",
+			Attribute:  "title",
 			Type:       db.ConstTypeVarchar,
 			IsRequired: false,
 			IsStatic:   true,

--- a/app/actors/cms/page/page.i_storable.go
+++ b/app/actors/cms/page/page.i_storable.go
@@ -36,7 +36,7 @@ func (it *DefaultCMSPage) Load(id string) error {
 	it.Identifier = utils.InterfaceToString(dbValues["identifier"])
 	it.Enabled = utils.InterfaceToBool(dbValues["enabled"])
 
-	it.PageTitle = utils.InterfaceToString(dbValues["title"])
+	it.Title = utils.InterfaceToString(dbValues["title"])
 	it.Content = utils.InterfaceToString(dbValues["content"])
 
 	it.CreatedAt = utils.InterfaceToTime(dbValues["created_at"])


### PR DESCRIPTION
https://github.com/ottemo/dashboard/compare/develop_SEO_Page_attribute_naming_conflict

Fixed problem from dashboard side: it will be check attribute names and compare with new added by seo if so will change seo attribute name and use this unique names.
