### PR TITLE
[#91721090] Fix hash sign removing in foundation

### DIFF
--- a/app/helpers.go
+++ b/app/helpers.go
@@ -43,7 +43,7 @@ func GetDashboardURL(path string) string {
 // GetStorefrontURL returns url related to storefront server
 func GetStorefrontURL(path string) string {
 	baseURL := utils.InterfaceToString(env.ConfigGetValue(ConstConfigPathStorefrontURL))
-	return strings.TrimRight(baseURL, "#/") + "/#/" + path
+	return strings.TrimRight(baseURL, "/") + "/" + path
 }
 
 // GetFoundationURL returns url related to foundation server


### PR DESCRIPTION
- Fixed hash sign that was removed from URL in storefront, but was still present in email links from foundation.
