### PR TITLE
session expiry

### DIFF
--- a/api/decl.go
+++ b/api/decl.go
@@ -10,7 +10,6 @@ const (
 	ConstRESTOperationUpdate = "PUT"
 	ConstRESTOperationCreate = "POST"
 	ConstRESTOperationDelete = "DELETE"
-
 	ConstRESTActionParameter = "action"
 
 	ConstSessionKeyAdminRights = "adminRights"   // session key used to flag that user have admin rights

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -19,7 +19,7 @@ func StartSession(context InterfaceApplicationContext) (InterfaceSession, error)
 
 	request := context.GetRequest()
 	// use secure cookies if OTTEMOCOOKIE is set to a valid true value
-	flagSecure, err := strconv.ParseBool(os.Getenv("OTTEMOCOOKIE"))
+	flagSecure, err := strconv.ParseBool(os.Getenv("OTTEMO_SECURE_COOKIE"))
 	if err != nil {
 		flagSecure = false
 	}


### PR DESCRIPTION
- increase expiry to one year
- http only cookie
- prep for https secure flag, if we could add in an environment variable so that we could set this to Secure = true in production I'd be happy. Just not sure how to
