### PR TITLE
foundation shippable deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ "$BRANCH" == 'feature/maaz_deploy_to_host' ]; then
+if [ "$BRANCH" == 'develop' ]; then
     GIT_COMMIT=`echo $COMMIT | head -c 5` 
     scp -r $GOPATH/bin/foundation/ ottemo@$REMOTE_HOST:~/deploy/foundation-$GIT_COMMIT
     ssh ottemo@$REMOTE_HOST "cd /home/ottemo/deploy/ && ln -sf foundation-$GIT_COMMIT foundation-latest" 

--- a/shippable.yml
+++ b/shippable.yml
@@ -29,3 +29,4 @@ after_success:
     - REMOTE_HOST=blitz.ottemo.io bash deploy.sh
     - REMOTE_HOST=urbanity.ottemo.io bash deploy.sh
     - REMOTE_HOST=richkids.dev.ottemo.io bash deploy.sh
+    - REMOTE_HOST=kg.dev.ottemo.io bash deploy.sh


### PR DESCRIPTION
deploy.sh: 
- copies built executable to ~/deploy/foundation-$commitHash 
- stops ottemo and copies existing foundation to ~/foundation/backup/foundation-$date
- copies new foundation in place and starts ottemo

Currently deploys to:
- blitz
- urbanity
- richkids.dev
- kg.dev

Leaving RichKids production server on manual update.
