### PR TITLE
add shipping notes

### DIFF
--- a/app/actors/checkout/api.go
+++ b/app/actors/checkout/api.go
@@ -99,8 +99,8 @@ func APIGetCheckout(context api.InterfaceApplicationContext) (interface{}, error
 	if shippingAddress := currentCheckout.GetShippingAddress(); shippingAddress != nil {
 		shippingAddressMap := shippingAddress.ToHashMap()
 
-		if shippingNote := utils.InterfaceToString(currentCheckout.GetInfo("shipping_note")); shippingNote != "" {
-			shippingAddressMap["shipping_note"] = shippingNote
+		if notes := utils.InterfaceToString(currentCheckout.GetInfo("notes")); notes != "" {
+			shippingAddressMap["notes"] = notes
 		}
 
 		result["shipping_address"] = shippingAddressMap
@@ -308,8 +308,8 @@ func APISetShippingAddress(context api.InterfaceApplicationContext) (interface{}
 
 	requestContents, _ := api.GetRequestContentAsMap(context)
 
-	if shippingNote, present := requestContents["shipping_note"]; present {
-		currentCheckout.SetInfo("shipping_note", shippingNote)
+	if notes, present := requestContents["notes"]; present {
+		currentCheckout.SetInfo("notes", notes)
 	}
 
 	// updating session

--- a/app/actors/checkout/i_checkout.go
+++ b/app/actors/checkout/i_checkout.go
@@ -507,9 +507,10 @@ func (it *DefaultCheckout) Submit() (interface{}, error) {
 	shippingAddress := it.GetShippingAddress().ToHashMap()
 	checkoutOrder.Set("shipping_address", shippingAddress)
 
-	if shippingNote := utils.InterfaceToString(it.GetInfo("shipping_note")); shippingNote != "" {
+	// this is a hack until we decide all customers want notes on addresses - jwv 20150630
+	if notes := utils.InterfaceToString(it.GetInfo("notes")); notes != "" {
 		shippingInfo := utils.InterfaceToMap(checkoutOrder.Get("shipping_info"))
-		shippingInfo["shipping_note"] = shippingNote
+		shippingInfo["notes"] = notes
 		checkoutOrder.Set("shipping_info", shippingInfo)
 	}
 

--- a/app/actors/order/api.go
+++ b/app/actors/order/api.go
@@ -109,8 +109,8 @@ func APIGetOrder(context api.InterfaceApplicationContext) (interface{}, error) {
 	}
 
 	result := orderModel.ToHashMap()
-	if shippingNote, present := utils.InterfaceToMap(result["shipping_info"])["shipping_note"]; present {
-		utils.InterfaceToMap(result["shipping_address"])["shipping_note"] = shippingNote
+	if notes, present := utils.InterfaceToMap(result["shipping_info"])["notes"]; present {
+		utils.InterfaceToMap(result["shipping_address"])["notes"] = notes
 	}
 
 	result["items"] = orderModel.GetItems()


### PR DESCRIPTION
**Note**
This is a less intrusive solution versus extending Address to support notes.  If we decide we need to store these notes with address, we can extend Address at a later time.  In the meantime, notes are presented both within shipping info, shipping address and the order.  
