### PR TITLE
add payment and shipping names to order

### DIFF
--- a/app/actors/checkout/i_checkout.go
+++ b/app/actors/checkout/i_checkout.go
@@ -507,12 +507,13 @@ func (it *DefaultCheckout) Submit() (interface{}, error) {
 	shippingAddress := it.GetShippingAddress().ToHashMap()
 	checkoutOrder.Set("shipping_address", shippingAddress)
 
-	// this is a hack until we decide all customers want notes on addresses - jwv 20150630
+	shippingInfo := utils.InterfaceToMap(checkoutOrder.Get("shipping_info"))
+	shippingInfo["shipping_method_name"] = it.GetShippingMethod().GetName()
 	if notes := utils.InterfaceToString(it.GetInfo("notes")); notes != "" {
-		shippingInfo := utils.InterfaceToMap(checkoutOrder.Get("shipping_info"))
 		shippingInfo["notes"] = notes
-		checkoutOrder.Set("shipping_info", shippingInfo)
 	}
+	checkoutOrder.Set("shipping_info", shippingInfo)
+	checkoutOrder.Set("shipping_method", it.GetShippingMethod().GetCode()+"/"+it.GetShippingRate().Code)
 
 	checkoutOrder.Set("cart_id", currentCart.GetID())
 
@@ -523,7 +524,9 @@ func (it *DefaultCheckout) Submit() (interface{}, error) {
 	}
 
 	checkoutOrder.Set("payment_method", paymentMethod.GetCode())
-	checkoutOrder.Set("shipping_method", it.GetShippingMethod().GetCode()+"/"+it.GetShippingRate().Code)
+	paymentInfo := utils.InterfaceToMap(checkoutOrder.Get("payment_info"))
+	paymentInfo["payment_method_name"] = it.GetPaymentMethod().GetName()
+	checkoutOrder.Set("payment_info", paymentInfo)
 
 	discounts := it.GetDiscounts()
 	discountAmount := it.GetDiscountAmount()


### PR DESCRIPTION
I added both **payment_method_name** and **shipping_method_name** to their respective info objects.  If you want them on the order itself, can copy them there for your convenience.  Let me know.

![image](https://cloud.githubusercontent.com/assets/713960/8740977/10283136-2c07-11e5-9014-c7ca9a81150f.png)
