### PR TITLE
improve utils in..toTime to convert unix string, used for sorting val…

### DIFF
--- a/utils/datatypes.go
+++ b/utils/datatypes.go
@@ -478,7 +478,6 @@ func InterfaceToTime(value interface{}) time.Time {
 	case time.Time:
 		return typedValue
 	case string:
-
 		tryFirst := []string{time.RFC3339, time.UnixDate}
 
 		for _, currentFormat := range tryFirst {
@@ -502,6 +501,12 @@ func InterfaceToTime(value interface{}) time.Time {
 					}
 				}
 			}
+		}
+
+		// convert to time from string of unix timestamp
+		newValue, err := strconv.ParseInt(typedValue, 10, 64)
+		if err == nil {
+			return time.Unix(newValue, 0)
 		}
 	}
 


### PR DESCRIPTION
…ue converting

Fix the problem with sorting by date for mongo db, so it's allows utils.interfaceToTime() to parse unix String as a number an return it's time value.
