### PR TITLE
[#106489130] expect utc date from dashboard for coupons endpoint

### DIFF
--- a/app/actors/discount/coupon/api.go
+++ b/app/actors/discount/coupon/api.go
@@ -457,13 +457,12 @@ func APIUpdateDiscount(context api.InterfaceApplicationContext) (interface{}, er
 		}
 	}
 
-	timeZone := utils.InterfaceToString(env.ConfigGetValue(app.ConstConfigPathStoreTimeZone))
 	if value, present := postValues["until"]; present {
-		record["until"], _ = utils.MakeUTCTime(utils.InterfaceToTime(value), timeZone)
+		record["until"] = utils.InterfaceToTime(value)
 	}
 
 	if value, present := postValues["since"]; present {
-		record["since"], _ = utils.MakeUTCTime(utils.InterfaceToTime(value), timeZone)
+		record["since"] = utils.InterfaceToTime(value)
 	}
 
 	// saving updates


### PR DESCRIPTION
- we now support timezones in the dashboard code, so we can remove this hack

https://www.pivotaltracker.com/story/show/106489130
https://github.com/ottemo/dashboard/pull/204
https://github.com/ottemo/dashboard/pull/205
