### PR TITLE
[#105807058] add filter for trust pilot emails

### DIFF
--- a/app/actors/other/trustpilot/init.go
+++ b/app/actors/other/trustpilot/init.go
@@ -116,8 +116,8 @@ func onAppStart() error {
 	env.EventRegisterListener("checkout.success", checkoutSuccessHandler)
 
 	if scheduler := env.GetScheduler(); scheduler != nil {
-		scheduler.RegisterTask("checkOrdersToSent", schedulerFunc)
-		scheduler.ScheduleRepeat("0 9 * * *", "checkOrdersToSent", nil)
+		scheduler.RegisterTask("trustPilotReview", schedulerFunc)
+		scheduler.ScheduleRepeat("0 9 * * *", "trustPilotReview", nil)
 	}
 
 	return nil


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/105807058
and then in another PR I've modified the scheduler endpoints to let you fire a function once 
# Testing Notes

The staging db has all of the orders flagged as "trustpilot_sent: true" so the cron task doesn't fire emails on staging.
1. enabling the mongo debugger variable `db/mongo/decl.go`
2. so hit `/cron/tasks` to get a list of registered tasks
3. you should see `trustPilotReview`
4. then you can hit `/cron/firenow/trustPilotReview`
5. you can then check the `mongo.log` file to see the db query that was generated while firing that task.
