### PR TITLE
[#108263376] add firenow endpoint

### DIFF
--- a/env/cron/api.go
+++ b/env/cron/api.go
@@ -41,7 +41,31 @@ func setupAPI() error {
 		return env.ErrorDispatch(err)
 	}
 
+	err = api.GetRestService().RegisterAPI("cron/firenow/:taskName", api.ConstRESTOperationGet, fireNow)
+	if err != nil {
+		return env.ErrorDispatch(err)
+	}
+
 	return nil
+}
+
+// Given a task name it will schedule a task to fire immediately
+func fireNow(context api.InterfaceApplicationContext) (interface{}, error) {
+
+	// check rights
+	if err := api.ValidateAdminRights(context); err != nil {
+		return nil, env.ErrorDispatch(err)
+	}
+
+	cronExpression := "* * * * * *" // Fire immediately
+	taskName := context.GetRequestArgument("taskName")
+	taskParams := make(map[string]interface{})
+
+	scheduler := env.GetScheduler()
+	var newSchedule env.InterfaceSchedule
+	newSchedule, _ = scheduler.ScheduleOnce(cronExpression, taskName, taskParams)
+
+	return newSchedule, nil
 }
 
 // getSchedules to get information about current schedules


### PR DESCRIPTION
Wrote this while trying to test https://github.com/ottemo/foundation/pull/234
Thought it might be helpful to leave it in.

I didn't make the changes because it seemed like divergent clean up work from this task, but I think the naming conventions in this api are goofy and should be
- `GET /cron/schedules -> getSchedules`
- `POST /cron/schedules -> createSchedule`
- `GET /cron/tasks -> getTasks`
- rm : enableSchedule
- rm : disableSchedule
- `PUT /cron/schedules/:scheduleID -> updateSchedule` // requires a little more rewriting
