### PR TITLE
[#104146442] fixed for different size names usage

### DIFF
--- a/app/actors/product/api.go
+++ b/app/actors/product/api.go
@@ -329,9 +329,8 @@ func APIGetProduct(context api.InterfaceApplicationContext) (interface{}, error)
 	if defaultImage != "" && len(itemImages) > 1 {
 		found := false
 		for index, images := range itemImages {
-			for sizeName, sizeValue := range images {
-				basicName := strings.Replace(sizeValue, "_"+sizeName, "", -1)
-				if strings.Contains(basicName, defaultImage) {
+			for _, sizeValue := range images {
+				if strings.Contains(sizeValue, defaultImage) {
 					found = true
 					itemImages = append(itemImages[:index], itemImages[index+1:]...)
 					itemImages = append([]map[string]string{images}, itemImages...)
@@ -717,13 +716,11 @@ func APIListProducts(context api.InterfaceApplicationContext) (interface{}, erro
 
 		// move default image to first position in array
 		if listItem.Image != "" && len(itemImages) > 1 {
-			defaultImageName := listItem.Image[strings.LastIndex(listItem.Image, "/")+1 : len(listItem.Image)]
+			defaultImageName := listItem.Image[strings.LastIndex(listItem.Image, "/")+1 : strings.Index(listItem.Image, ".")]
 			found := false
 			for index, images := range itemImages {
-				for sizeName, sizeValue := range images {
-
-					basicName := strings.Replace(sizeValue, "_"+sizeName, "", -1)
-					if strings.Contains(basicName, defaultImageName) {
+				for _, sizeValue := range images {
+					if strings.Contains(sizeValue, defaultImageName) {
 						found = true
 						itemImages = append(itemImages[:index], itemImages[index+1:]...)
 						itemImages = append([]map[string]string{images}, itemImages...)


### PR DESCRIPTION
basicName := strings.Replace(sizeValue, "_"+sizeName, "", -1)
it's deprecated after switching to different name/size values, and last part prevent from finding name of default image in resized image with full path.
