### PR TITLE
[#104735620] collect current month stats

### DIFF
--- a/app/actors/rts/api.go
+++ b/app/actors/rts/api.go
@@ -154,14 +154,16 @@ func APIGetVisits(context api.InterfaceApplicationContext) (interface{}, error) 
 	weekTotalVisits := yesterdayVisits + todayVisits + weekStats.TotalVisits
 
 	result["total"] = map[string]int{
-		"today":     todayTotalVisits,
-		"yesterday": yesterdayTotalVisits,
-		"week":      weekTotalVisits,
+		"today":         todayTotalVisits,
+		"yesterday":     yesterdayTotalVisits,
+		"week":          weekTotalVisits,
+		"month to date": monthStatistic.TotalVisits,
 	}
 	result["unique"] = map[string]int{
-		"today":     todayVisits,
-		"yesterday": yesterdayVisits,
-		"week":      weekVisits,
+		"today":         todayVisits,
+		"yesterday":     yesterdayVisits,
+		"week":          weekVisits,
+		"month to date": monthStatistic.Visit,
 	}
 
 	return result, nil
@@ -349,14 +351,17 @@ func APIGetSales(context api.InterfaceApplicationContext) (interface{}, error) {
 	weekSalesAmount := todaySalesAmount + yesterdaySalesAmount + weekStats.SalesAmount
 
 	result["sales"] = map[string]float64{
-		"today":     todaySalesAmount,
-		"yesterday": yesterdaySalesAmount,
-		"week":      weekSalesAmount,
+		"today":         todaySalesAmount,
+		"yesterday":     yesterdaySalesAmount,
+		"week":          weekSalesAmount,
+		"month to date": monthStatistic.SalesAmount,
 	}
+
 	result["orders"] = map[string]int{
-		"today":     todaySales,
-		"yesterday": yesterdaySales,
-		"week":      weekSales,
+		"today":         todaySales,
+		"yesterday":     yesterdaySales,
+		"week":          weekSales,
+		"month to date": monthStatistic.Sales,
 	}
 
 	return result, nil

--- a/app/actors/rts/decl.go
+++ b/app/actors/rts/decl.go
@@ -32,8 +32,9 @@ const (
 var (
 	updateSync sync.RWMutex
 
-	referrers = make(map[string]int)         // collects and counts refers from external sites
-	statistic = make(map[int64]*ActionsMade) // information about per hour site activity
+	referrers      = make(map[string]int)         // collects and counts refers from external sites
+	statistic      = make(map[int64]*ActionsMade) // information about per hour site activity
+	monthStatistic = new(ActionsMade)             // information total month activity
 
 	lastUpdate = time.Now()            // last update timer for day reset
 	visitState = make(map[string]bool) // reflects session state: 1) not present - new visit, 2) false - addToCart not happened, 3) true - addToCart happened

--- a/app/actors/rts/handlers.go
+++ b/app/actors/rts/handlers.go
@@ -56,12 +56,14 @@ func visitsHandler(event string, eventData map[string]interface{}) bool {
 			CheckHourUpdateForStatistic()
 			if _, present := statistic[currentHour]; present && statistic[currentHour] != nil {
 				statistic[currentHour].TotalVisits++
+				monthStatistic.TotalVisits++
 			}
 
 			if _, present := visitState[sessionID]; !present {
 				visitState[sessionID] = false
 				if _, present := statistic[currentHour]; present && statistic[currentHour] != nil {
 					statistic[currentHour].Visit++
+					monthStatistic.Visit++
 				}
 
 				err := SaveStatisticsData()
@@ -90,6 +92,7 @@ func addToCartHandler(event string, eventData map[string]interface{}) bool {
 
 					if _, present := statistic[currentHour]; present && statistic[currentHour] != nil {
 						statistic[currentHour].Cart++
+						monthStatistic.Cart++
 					}
 
 					err := SaveStatisticsData()
@@ -126,6 +129,7 @@ func visitCheckoutHandler(event string, eventData map[string]interface{}) bool {
 
 	if _, present := statistic[currentHour]; present && statistic[currentHour] != nil {
 		statistic[currentHour].VisitCheckout++
+		monthStatistic.VisitCheckout++
 	}
 
 	err := SaveStatisticsData()
@@ -143,6 +147,7 @@ func setPaymentHandler(event string, eventData map[string]interface{}) bool {
 
 	if _, present := statistic[currentHour]; present && statistic[currentHour] != nil {
 		statistic[currentHour].SetPayment++
+		monthStatistic.SetPayment++
 	}
 
 	err := SaveStatisticsData()
@@ -173,6 +178,11 @@ func purchasedHandler(event string, eventData map[string]interface{}) bool {
 					statistic[currentHour].Cart++
 					statistic[currentHour].VisitCheckout++
 					statistic[currentHour].SetPayment++
+					monthStatistic.Visit++
+					monthStatistic.TotalVisits++
+					monthStatistic.Cart++
+					monthStatistic.VisitCheckout++
+					monthStatistic.SetPayment++
 				}
 			}
 
@@ -180,6 +190,8 @@ func purchasedHandler(event string, eventData map[string]interface{}) bool {
 			if _, present := statistic[currentHour]; present && statistic[currentHour] != nil {
 				statistic[currentHour].Sales++
 				statistic[currentHour].SalesAmount += saleAmount
+				monthStatistic.Sales++
+				monthStatistic.SalesAmount += saleAmount
 			}
 
 			err := SaveStatisticsData()


### PR DESCRIPTION
monthStatistic now collecting on fly stats for current month activity. upon reaching new month it will be cleared at all without save (we are storing same stats on per hour basics, so can get same info in detail request)
