### PR TITLE
[#110212580] gift cards should be charged taxes or shipping

### DIFF
--- a/app/actors/discount/giftcard/decl.go
+++ b/app/actors/discount/giftcard/decl.go
@@ -30,3 +30,5 @@ const (
 
 // DefaultGiftcard is a default implementer of InterfaceDiscount
 type DefaultGiftcard struct{}
+
+type GiftcardShipping struct{}

--- a/app/actors/discount/giftcard/i_shipping_method.go
+++ b/app/actors/discount/giftcard/i_shipping_method.go
@@ -1,0 +1,56 @@
+package giftcard
+
+import (
+	"strings"
+
+	"github.com/ottemo/foundation/app/models/checkout"
+	"github.com/ottemo/foundation/env"
+	"github.com/ottemo/foundation/utils"
+)
+
+// GetName returns name of shipping method
+func (it *GiftcardShipping) GetName() string {
+	return "No Shipping"
+}
+
+// GetCode returns code of shipping method
+func (it *GiftcardShipping) GetCode() string {
+	return "giftcards"
+}
+
+// IsAllowed checks for method applicability
+func (it *GiftcardShipping) IsAllowed(checkout checkout.InterfaceCheckout) bool {
+	return true
+}
+
+// GetRates returns rates allowed by shipping method for a given checkout
+func (it *GiftcardShipping) GetRates(currentCheckout checkout.InterfaceCheckout) []checkout.StructShippingRate {
+
+	result := []checkout.StructShippingRate{}
+
+	giftCardSkuElement := utils.InterfaceToString(env.ConfigGetValue(ConstConfigPathGiftCardSKU))
+
+	if cart := currentCheckout.GetCart(); cart != nil {
+		for _, cartItem := range cart.GetItems() {
+
+			cartProduct := cartItem.GetProduct()
+			if cartProduct == nil {
+				continue
+			}
+
+			cartProduct.ApplyOptions(cartItem.GetOptions())
+			if !strings.Contains(cartProduct.GetSku(), giftCardSkuElement) {
+				return result
+			}
+		}
+	}
+
+	result = []checkout.StructShippingRate{
+		checkout.StructShippingRate{
+			Code:  "freeshipping",
+			Name:  "GiftCards",
+			Price: 0,
+		}}
+
+	return result
+}

--- a/app/actors/discount/giftcard/init.go
+++ b/app/actors/discount/giftcard/init.go
@@ -12,7 +12,12 @@ import (
 func init() {
 	instance := new(DefaultGiftcard)
 	var _ checkout.InterfaceDiscount = instance
+
 	checkout.RegisterDiscount(instance)
+
+	giftCardFreeShipping := new(GiftcardShipping)
+	var _ checkout.InterfaceShippingMethod = giftCardFreeShipping
+	checkout.RegisterShippingMethod(giftCardFreeShipping)
 
 	db.RegisterOnDatabaseStart(setupDB)
 	env.RegisterOnConfigStart(setupConfig)
@@ -54,6 +59,7 @@ func onAppStart() error {
 	env.EventRegisterListener("checkout.success", checkoutSuccessHandler)
 	env.EventRegisterListener("order.proceed", orderProceedHandler)
 	env.EventRegisterListener("order.rollback", orderRollbackHandler)
+	env.EventRegisterListener("tax.amount", taxableAmountHandler)
 
 	if scheduler := env.GetScheduler(); scheduler != nil {
 		scheduler.RegisterTask("sendGiftCards", SendTask)


### PR DESCRIPTION
## Notes

This is a hotfix for not charging taxes and free shipping when gift cards are purchased.  
#### Previous Commits

these commits were squashed: 
- [#110212580] updated exclude of gift card from tax calculate, different types of taxes now can work differently
- fix value compare
- [#110212580] Giftcards freeshipping
- [#110212580] change method name to GiftCards
- rename shipping rate and name
