### PR TITLE
[#103204990] use grand total instead of subtotal in RTS sales

### DIFF
--- a/app/actors/rts/handlers.go
+++ b/app/actors/rts/handlers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ottemo/foundation/api"
 	"github.com/ottemo/foundation/app"
 	"github.com/ottemo/foundation/app/models/cart"
+	"github.com/ottemo/foundation/app/models/order"
 	"github.com/ottemo/foundation/db"
 	"github.com/ottemo/foundation/env"
 	"github.com/ottemo/foundation/utils"
@@ -163,8 +164,8 @@ func purchasedHandler(event string, eventData map[string]interface{}) bool {
 	if sessionInstance, ok := eventData["session"].(api.InterfaceSession); ok && sessionInstance != nil {
 		if sessionID := sessionInstance.GetID(); sessionID != "" {
 			saleAmount := float64(0)
-			if cartInstance, ok := eventData["cart"].(cart.InterfaceCart); ok {
-				saleAmount = cartInstance.GetSubtotal()
+			if orderInstance, ok := eventData["order"].(order.InterfaceOrder); ok {
+				saleAmount = orderInstance.GetGrandTotal()
 			}
 
 			currentHour := time.Now().Truncate(time.Hour).Unix()


### PR DESCRIPTION
https://www.pivotaltracker.com/projects/1457414/stories/103204990

Tested by placing an order on kg with coupon code `REALSIMPLE15`

Issues I noticed while digging around
1. We don't have all of the "columns" in kg.staging that are defined in `foundation/app/actors/rts/init.go@setupDB`
2. refferer can only come from known search engine?? `foundation/app/actors/rts/decl.go`
