### PR TITLE
[#112831153] fedex should check if it is enabled

### DIFF
--- a/app/actors/shipping/fedex/i_shipping_method.go
+++ b/app/actors/shipping/fedex/i_shipping_method.go
@@ -25,7 +25,7 @@ func (it *FedEx) GetCode() string {
 
 // IsAllowed checks for method applicability
 func (it *FedEx) IsAllowed(checkout checkout.InterfaceCheckout) bool {
-	return true
+	return utils.InterfaceToBool(env.ConfigGetValue(ConstConfigPathEnabled))
 }
 
 // GetRates returns rates allowed by shipping method for a given checkout


### PR DESCRIPTION
I finished part one of this bug.
The second part is to figure out why the `xmlpath.Parse` is choking on Fedex's error.
