### PR TITLE
[#114907917] recognize decimal type as a float

### DIFF
--- a/utils/datatypes.go
+++ b/utils/datatypes.go
@@ -152,7 +152,7 @@ func DataTypeParse(typeName string) DataType {
 		result.Name = ConstDataTypeInteger
 		result.IsKnown = true
 
-	case IsAmongStr(result.Name, "f", "d", "flt", "dbl", "float", "double"):
+	case IsAmongStr(result.Name, "f", "d", "flt", "dbl", "float", "double", "decimal", "money"):
 		result.Name = ConstDataTypeFloat
 		result.IsKnown = true
 


### PR DESCRIPTION
We changed the dashboard to send up "float" instead of "decimal" as the type, because the server sends down "float" and not "decimal". This is the kind of issue i was referring to from the planning meeting about "solidifying the contract between the server and client"
