### PR TITLE
do not encrypt config passwords for admins

### DIFF
--- a/env/config/i_config.go
+++ b/env/config/i_config.go
@@ -246,7 +246,7 @@ func (it *DefaultConfig) GetItemsInfo(Path string) []env.StructConfigItem {
 
 		configItem := env.StructConfigItem{
 			Path:  utils.InterfaceToString(record["path"]),
-			Value: record["value"],
+			Value: it.GetValue(utils.InterfaceToString(record["path"])),
 
 			Type: utils.InterfaceToString(record["type"]),
 


### PR DESCRIPTION
We were encrypting for:  http://api.local.dev/config/item/store

But not for: http://api.local.dev/config/value/general.store.root_password

Now both are decrypted for admin users.
