### PR TITLE
save jpegs at 80% quality

### DIFF
--- a/media/fsmedia/image.go
+++ b/media/fsmedia/image.go
@@ -3,6 +3,7 @@ package fsmedia
 import (
 	"fmt"
 	"image"
+	"image/jpeg"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -242,9 +243,15 @@ func (it *FilesystemMediaStorage) ResizeMediaImage(model string, objID string, m
 			}
 		}
 
-		err = imaging.Save(resizedImage, destinationFileName)
+		file, err := os.Create(destinationFileName)
 		if err != nil {
 			return env.ErrorDispatch(err)
+		}
+		defer file.Close()
+
+		err = jpeg.Encode(file, resizedImage, &jpeg.Options{Quality: 80})
+		if err != nil {
+			env.ErrorDispatch(err)
 		}
 	}
 


### PR DESCRIPTION
## on deploy

foundation will only create files for dimensions that don't exist
**note: we should do this on staging then rsync them up to prod or something, it is kind of slow**
1. delete all modified files, `find ./ -type f -name '*[0-9]x[0-9]*.jpg' -delete`
1. tell foundation to rebuild them all `http://api.local.dev/media?resizeAll=true` on my local this errors a little, saying that it can't find all files. not sure what that is about
## testing notes
1. we should perf test 
   1. page load time changes
   2. img load time changes
   3. for pdp & shop all pages
2. we should see how this impacts our score on perf sites like webpagetest
## questions
1. is it OK that this code only supports jpegs now? i would expect product images to always be jpg...
