### PR TITLE
fix - add mutex lock to mongodb collection

### DIFF
--- a/db/mongo/collection.i_dbcollection.go
+++ b/db/mongo/collection.i_dbcollection.go
@@ -234,8 +234,13 @@ func (it *DBCollection) ListColumns() map[string]string {
 	}
 
 	// updating cached attribute types information
-	if _, present := attributeTypes[it.Name]; !present {
+	attributeTypesMutex.Lock()
+	_, present := attributeTypes[it.Name]
+	attributeTypesMutex.Unlock()
+	if !present {
+		attributeTypesMutex.Lock()
 		attributeTypes[it.Name] = make(map[string]string)
+		attributeTypesMutex.Unlock()
 	}
 
 	attributeTypesMutex.Lock()
@@ -255,11 +260,15 @@ func (it *DBCollection) GetColumnType(ColumnName string) string {
 	}
 
 	// looking in cache first
+	attributeTypesMutex.Lock()
 	attributeType, present := attributeTypes[it.Name][ColumnName]
+	attributeTypesMutex.Unlock()
 	if !present {
 		// updating cache, and looking again
 		it.ListColumns()
+		attributeTypesMutex.Lock()
 		attributeType, present = attributeTypes[it.Name][ColumnName]
+		attributeTypesMutex.Unlock()
 	}
 
 	return attributeType


### PR DESCRIPTION
This is to fix the panic we are currently getting for a read/write map issue when hitting the endpoint to list all orders in dashboard.

[#129748077]
