### PR TITLE
RB_reload_braintree_configuration

### DIFF
--- a/app/actors/payment/braintree/decl.go
+++ b/app/actors/payment/braintree/decl.go
@@ -48,5 +48,3 @@ const (
 
 // CreditCardMethod is a implementer of InterfacePaymentMethod for a Credit Card payment method
 type CreditCardMethod struct{}
-
-var braintreeInstance *braintree.Braintree

--- a/app/actors/payment/braintree/init.go
+++ b/app/actors/payment/braintree/init.go
@@ -3,27 +3,11 @@ package braintree
 import (
 	"github.com/ottemo/foundation/env"
 
-	"github.com/lionelbarrow/braintree-go"
-	"github.com/ottemo/foundation/app"
 	"github.com/ottemo/foundation/app/models/checkout"
-	"github.com/ottemo/foundation/utils"
 )
 
 // init makes package self-initialization routine
 func init() {
 	checkout.RegisterPaymentMethod(new(CreditCardMethod))
 	env.RegisterOnConfigStart(setupConfig)
-
-	app.OnAppStart(onAppStart)
-}
-
-func onAppStart() error {
-	braintreeInstance = braintree.New(
-		braintree.Environment(utils.InterfaceToString(env.ConfigGetValue(ConstGeneralConfigPathEnvironment))),
-		utils.InterfaceToString(env.ConfigGetValue(ConstGeneralConfigPathMerchantID)),
-		utils.InterfaceToString(env.ConfigGetValue(ConstGeneralConfigPathPublicKey)),
-		utils.InterfaceToString(env.ConfigGetValue(ConstGeneralConfigPathPrivateKey)),
-	)
-
-	return nil
 }


### PR DESCRIPTION
Braintree configuration should be reloaded at runtime to check changed values. So, braintreeInstance is no more part of package with initialization at start. Test has been added.