### PR TITLE
RB_fix_sirupsen_package_dependency

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,7 @@ import:
   subpackages:
   - memcache
 - package: github.com/bshuster-repo/logrus-logstash-hook
+  version: 0.3
 - package: github.com/dchest/captcha
 - package: github.com/disintegration/imaging
   version: v1.1.0


### PR DESCRIPTION
Glide had not set versions for all vendor packages during initialization. So, after update of github.com/bshuster-repo/logrus-logstash-hook build becomes broken. Setting exact version for this package fixed the issue.