### PR TITLE
RB Eliminate double data conversion

### DIFF
--- a/env/config/i_config.go
+++ b/env/config/i_config.go
@@ -248,7 +248,7 @@ func (it *DefaultConfig) GetItemsInfo(Path string) []env.StructConfigItem {
 
 		configItem := env.StructConfigItem{
 			Path:  utils.InterfaceToString(record["path"]),
-			Value: it.GetValue(utils.InterfaceToString(record["path"])),
+			Value: record["value"],
 
 			Type: utils.InterfaceToString(record["type"]),
 


### PR DESCRIPTION
it.GetValue returns already converted value.
Next, few lines below, db.ConvertTypeFromDbToGo again converts value.
It could affect https://github.com/ottemo/foundation/pull/347, where change has been introduced.

Also it fixes issue with invisible FlatRate rates after foundation restart.