### PR TITLE
rename to repo & binary to commerce ottemo/commerce#493

### DIFF
--- a/bin/make.sh
+++ b/bin/make.sh
@@ -59,11 +59,9 @@ LDFLAGS+="-X \"github.com/ottemo/foundation/app.buildBranch=$BRANCH\" "
 LDFLAGS+="-X \"github.com/ottemo/foundation/app.buildHash=$HASH\" "
 LDFLAGS+="'"
 
-# need to convert GOVERSION string to number
+# uncomment for go versions previous to 1.7 using the old linker
 #
-if [ "`${AWK} "BEGIN{ if (($GOVERSION +0) < 1.5) print 1 }"`" == "1" ]; then
-  LDFLAGS=${LDFLAGS//=/\" \"}
-fi
+#  LDFLAGS=${LDFLAGS//=/\" \"}
 
 if [ -z "$GOPATH" ]; then
 REPLACE="/src/$OTTEMOPKG"

--- a/bin/make.sh
+++ b/bin/make.sh
@@ -2,7 +2,7 @@
 
 WORKDIR=`pwd`
 OTTEMODIR="$(cd "$(dirname "$0")" && pwd)"
-OTTEMOPKG="github.com/ottemo/foundation"
+OTTEMOPKG="github.com/ottemo/commerce"
 
 # select the right version of awk
 #    on MacOS and Alpine you may need to install gawk

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/ottemo/foundation
+package: github.com/ottemo/commerce
 import:
 - package: github.com/Pallinder/go-randomdata
 - package: github.com/Sirupsen/logrus


### PR DESCRIPTION
@vnaz can you review this?

I updated glide, changed the build script to only work with the linker in go versions 1.7+, and changed the package name to `github.com/ottemo/commerce`